### PR TITLE
Develop -> Master - Fix for GitHub Actions Lacking Permissions to Create Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     tags-ignore:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   validate-and-publish:
     runs-on: ubuntu-latest

--- a/PSMimeTypes/PSMimeTypes.psd1
+++ b/PSMimeTypes/PSMimeTypes.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSMimeTypes.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.6'
+ModuleVersion = '1.0.7'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Fix for lacking permissions to generate a release
- Module version incremented to 1.0.7